### PR TITLE
added a menu for swift package commands and execute them with runTask

### DIFF
--- a/pkg/nuclide-swift/keymaps/swift.json
+++ b/pkg/nuclide-swift/keymaps/swift.json
@@ -1,0 +1,5 @@
+{
+  "atom-workspace": {
+    "ctrl-cmd-p": "nuclide-swift:create-new-package"
+  }
+}

--- a/pkg/nuclide-swift/lib/buildsystem/SwiftPMBuildSystem.js
+++ b/pkg/nuclide-swift/lib/buildsystem/SwiftPMBuildSystem.js
@@ -23,7 +23,16 @@ import {observeProcess, safeSpawn} from '../../../commons-node/process';
 import {observableToBuildTaskInfo} from '../../../commons-node/observableToBuildTaskInfo';
 import SwiftPMBuildSystemStore from './SwiftPMBuildSystemStore';
 import SwiftPMBuildSystemActions from './SwiftPMBuildSystemActions';
-import {buildCommand, testCommand} from './SwiftPMBuildSystemCommands';
+import {
+  buildCommand,
+  testCommand,
+  createNewPackageCommand,
+  fetchPackageDependenciesCommand,
+  updatePackageDependenciesCommand,
+  generateXcodeProjectCommand,
+  visualizePackageDependenciesCommand,
+  displayBufferDescriptionCommand,
+} from './SwiftPMBuildSystemCommands';
 import {
   SwiftPMBuildSystemBuildTask,
   SwiftPMBuildSystemTestTask,
@@ -119,10 +128,30 @@ export class SwiftPMBuildSystem {
 
   runTask(taskType: string): TaskInfo {
     let command;
-    if (taskType === SwiftPMBuildSystemBuildTask.type) {
-      command = buildCommand(this._store);
-    } else {
-      command = testCommand(this._store);
+    switch (taskType) {
+      case SwiftPMBuildSystemBuildTask.type:
+        command = buildCommand(this._store);
+        break;
+      case SwiftPMBuildSystemTestTask.type:
+        command = testCommand(this._store);
+        break;
+      case 'create-new-package':
+        command = createNewPackageCommand(this._store);
+        break;
+      case 'fetch-package-dependencies':
+        command = fetchPackageDependenciesCommand(this._store);
+        break;
+      case 'update-package-dependencies':
+        command = updatePackageDependenciesCommand(this._store);
+        break;
+      case 'generate-xcode-project':
+        command = generateXcodeProjectCommand(this._store);
+        break;
+      case 'visualize-package-dependencies':
+        command = visualizePackageDependenciesCommand(this._store);
+        break;
+      default:
+        command = displayBufferDescriptionCommand(this._store);
     }
 
     atom.commands.dispatch(atom.views.getView(atom.workspace), 'nuclide-console:show');

--- a/pkg/nuclide-swift/lib/buildsystem/SwiftPMBuildSystemCommands.js
+++ b/pkg/nuclide-swift/lib/buildsystem/SwiftPMBuildSystemCommands.js
@@ -57,6 +57,96 @@ export function testCommand(store: SwiftPMBuildSystemStore): {
   };
 }
 
+export function createNewPackageCommand(store: SwiftPMBuildSystemStore): {
+  command: string;
+  args: Array<string>
+} {
+  const commandArgs = [
+    'package',
+    'init',
+    '--chdir', store.getChdir(),
+  ];
+  return {
+    command: _swiftPath(),
+    args: commandArgs,
+  };
+}
+
+export function fetchPackageDependenciesCommand(store: SwiftPMBuildSystemStore): {
+  command: string;
+  args: Array<string>
+} {
+  const commandArgs = [
+    'package',
+    'fetch',
+    '--chdir', store.getChdir(),
+  ];
+  return {
+    command: _swiftPath(),
+    args: commandArgs,
+  };
+}
+
+export function updatePackageDependenciesCommand(store: SwiftPMBuildSystemStore): {
+  command: string;
+  args: Array<string>
+} {
+  const commandArgs = [
+    'package',
+    'update',
+    '--chdir', store.getChdir(),
+  ];
+  return {
+    command: _swiftPath(),
+    args: commandArgs,
+  };
+}
+
+export function generateXcodeProjectCommand(store: SwiftPMBuildSystemStore): {
+  command: string;
+  args: Array<string>
+} {
+  const commandArgs = [
+    'package',
+    'generate-xcodeproj',
+    '--chdir', store.getChdir(),
+  ];
+  return {
+    command: _swiftPath(),
+    args: commandArgs,
+  };
+}
+
+export function visualizePackageDependenciesCommand(store: SwiftPMBuildSystemStore): {
+  command: string;
+  args: Array<string>
+} {
+  const commandArgs = [
+    'package',
+    'show-dependencies',
+    '--chdir', store.getChdir(),
+  ];
+  return {
+    command: _swiftPath(),
+    args: commandArgs,
+  };
+}
+
+export function displayBufferDescriptionCommand(store: SwiftPMBuildSystemStore): {
+  command: string;
+  args: Array<string>
+} {
+  const commandArgs = [
+    'package',
+    'dump-package',
+    '--chdir', store.getChdir(),
+  ];
+  return {
+    command: _swiftPath(),
+    args: commandArgs,
+  };
+}
+
 function _swiftPath(): string {
   const path = (featureConfig.get('nuclide-swift.swiftToolchainPath'): any);
   if (path) {

--- a/pkg/nuclide-swift/lib/main.js
+++ b/pkg/nuclide-swift/lib/main.js
@@ -30,6 +30,14 @@ export function activate(rawState: ?Object): void {
   invariant(_disposables == null);
   _disposables = new CompositeDisposable(
     new Disposable(),
+    atom.commands.add('atom-workspace', {
+      'nuclide-swift:create-new-package': () => _getBuildSystem().runTask('create-new-package'),
+      'nuclide-swift:fetch-packages-dependencies': () => _getBuildSystem().runTask('fetch-package-dependencies'),
+      'nuclide-swift:update-package-dependencies': () => _getBuildSystem().runTask('update-package-dependencies'),
+      'nuclide-swift:generate-xcode-project': () => _getBuildSystem().runTask('generate-xcode-project'),
+      'nuclide-swift:visualize-package-dependencies': () => _getBuildSystem().runTask('visualize-package-dependencies'),
+      'nuclide-swift:display-buffer-description': () => _getBuildSystem().runTask('display-buffer-description')
+    }),
   );
 }
 

--- a/pkg/nuclide-swift/menus/nuclide-swift.json
+++ b/pkg/nuclide-swift/menus/nuclide-swift.json
@@ -1,0 +1,38 @@
+{
+  "menu": [
+    {
+      "label": "Nuclide",
+      "submenu": [
+        {
+          "label": "Swift",
+          "submenu": [
+            {
+              "label": "Create New Package",
+              "command": "nuclide-swift:create-new-package"
+            },
+            {
+              "label": "Fetch Current Package’s Dependencies",
+              "command": "nuclide-swift:fetch-package-dependencies"
+            },
+            {
+              "label": "Update Current Package’s Dependencies",
+              "command": "nuclide-swift:update-package-dependencies"
+            },
+            {
+              "label": "Generate Xcode Project for Current Package",
+              "command": "nuclide-swift:generate-xcode-project"
+            },
+            {
+              "label": "Visualize Current Package’s Dependencies",
+              "command": "nuclide-swift:visualize-package-dependencies"
+            },
+            {
+              "label": "Display Buffer for Current Package’s Description as JSON",
+              "command": "nuclide-swift:display-buffer-description"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#3

Tried adding a shortcut for new package, not sure if it's legit or what the other shortcuts should look like

init has a few types: library|executable|system-module, but this ignores that for now, and also init uses the path to swift instead of perhaps prompting the user where the new package should go
