### PR TITLE
Add first snippet: for-in

### DIFF
--- a/pkg/nuclide-swift/snippets/snippets.cson
+++ b/pkg/nuclide-swift/snippets/snippets.cson
@@ -1,0 +1,8 @@
+'.source.swift':
+  'for-in':
+    'prefix': 'for'
+    'body': """
+      for ${1:item} in ${2:collection} {
+        ${3:statements}
+      }
+    """


### PR DESCRIPTION
This adds a first snippet for `for-in` loops.

I've tested this in `~/.atom/snippets.cson` but have not tested this via nuclide-swift. I guess I should do that.

Resolves #15 
