### PR TITLE
Remove implicit language-swift dependency

### DIFF
--- a/pkg/nuclide-swift/grammars/swift.cson
+++ b/pkg/nuclide-swift/grammars/swift.cson
@@ -1,0 +1,5 @@
+'scopeName': 'source.swift'
+'fileTypes': [
+  'swift'
+],
+'name': 'Swift'


### PR DESCRIPTION
Adds a nearly-blank grammar so that Atom recognizes Swift files and can autocomplete, etc., without having to rely on the presence of the community `language-swift` package. Addresses #32 

![screen shot 2016-07-19 at 2 15 39 pm](https://cloud.githubusercontent.com/assets/73101/16965072/b1864d20-4dbb-11e6-8246-894ced343701.png)
